### PR TITLE
Reorient widget layout and styling for Notion

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,17 +15,20 @@
       --padX: 10px;
       --padY: 8px;
       --gap: 8px;
+      --row-gap: 4px;
       --maxw: 100%; /* fits narrow Notion column */
       --barH: 10px; /* Equal thickness for all bars */
       --labelW: 62px; /* wider for mixed case labels */
+      --border: var(--fg);
     }
     @media (prefers-color-scheme: dark){
       :root{
-        --bg: #000000;
+        --bg: #191919;
         --fg: #eeeeee;
         --track: #1f1f1f;
         --fill: #eeeeee;
         --label: #aaaaaa;
+        --border: var(--fg);
       }
     }
     html,body{
@@ -33,7 +36,7 @@
       margin:0;
       background:var(--bg);
       color:var(--fg);
-      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+      font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       color-scheme: light dark;
     }
     .wrap{
@@ -43,7 +46,7 @@
       padding: var(--padY) var(--padX);
     }
     .stack{ display:flex; flex-direction: column; gap: var(--gap); }
-    .row{ display:flex; align-items: center; gap: 8px; }
+    .row{ display:flex; align-items: center; gap: var(--row-gap); }
     .label{
       width: var(--labelW);
       font-size: 12px;
@@ -51,6 +54,7 @@
       color: var(--label);
       user-select: none;
       white-space: nowrap;
+      text-align: left;
     }
     .track{
       position: relative;
@@ -58,6 +62,8 @@
       height: var(--barH); /* equal thickness */
       background: var(--track);
       border-radius: var(--radius);
+      border: 1px solid var(--border);
+      box-sizing: border-box;
       overflow: hidden;
     }
     .fill{
@@ -74,29 +80,29 @@
 <body>
   <div class="wrap" role="group" aria-label="Time progress bars">
     <div class="stack" id="stack">
-      <div class="row day">
-        <div class="label">Day</div>
-        <div class="track" tabindex="0" role="progressbar" aria-label="Day progress" aria-valuemin="0" aria-valuemax="100">
-          <div class="fill" id="bar-day"></div>
-        </div>
-      </div>
-      <div class="row week">
-        <div class="label">Week</div>
-        <div class="track" tabindex="0" role="progressbar" aria-label="Week progress" aria-valuemin="0" aria-valuemax="100">
-          <div class="fill" id="bar-week"></div>
-        </div>
-      </div>
-      <div class="row month">
-        <div class="label">Month</div>
-        <div class="track" tabindex="0" role="progressbar" aria-label="Month progress" aria-valuemin="0" aria-valuemax="100">
-          <div class="fill" id="bar-month"></div>
-        </div>
-      </div>
       <div class="row year">
-        <div class="label">Year</div>
         <div class="track" tabindex="0" role="progressbar" aria-label="Year progress" aria-valuemin="0" aria-valuemax="100">
           <div class="fill" id="bar-year"></div>
         </div>
+        <div class="label">Year</div>
+      </div>
+      <div class="row month">
+        <div class="track" tabindex="0" role="progressbar" aria-label="Month progress" aria-valuemin="0" aria-valuemax="100">
+          <div class="fill" id="bar-month"></div>
+        </div>
+        <div class="label">Month</div>
+      </div>
+      <div class="row week">
+        <div class="track" tabindex="0" role="progressbar" aria-label="Week progress" aria-valuemin="0" aria-valuemax="100">
+          <div class="fill" id="bar-week"></div>
+        </div>
+        <div class="label">Week</div>
+      </div>
+      <div class="row day">
+        <div class="track" tabindex="0" role="progressbar" aria-label="Day progress" aria-valuemin="0" aria-valuemax="100">
+          <div class="fill" id="bar-day"></div>
+        </div>
+        <div class="label">Day</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Display year, month, week and day bars in descending order with labels moved to the right
- Use Inter-based sans-serif font and tighten spacing for a cleaner Notion look
- Add subtle borders and update dark theme background to match Notion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adccf1e8c48332bf29265a4d174308