### PR TITLE
Remove progress bar artefact and adjust spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       --padX: 16px;
       --padY: 16px;
       --gap: 14px;
-      --row-gap: 7px;
+      --row-gap: 10px;
       --maxw: 100%; /* fits narrow Notion column */
       --barH: 12px; /* slightly thicker bars */
       --labelW: 72px; /* wider for mixed case labels */
@@ -61,7 +61,7 @@
       height: var(--barH); /* equal thickness */
       background: var(--track);
       border-radius: var(--radius);
-      border: 1px solid var(--border);
+      box-shadow: 0 0 0 1px var(--border);
       box-sizing: border-box;
       overflow: hidden;
     }
@@ -70,7 +70,7 @@
       inset: 0 auto 0 0; /* left to right fill */
       width: 0%;
       background: var(--fill);
-      border-radius: var(--radius);
+      border-radius: 0 var(--radius) var(--radius) 0;
       transition: width 0.6s ease;
     }
     .track:focus-visible{ outline: 2px solid var(--fill); outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- eliminate left-edge artefact by changing track border to box-shadow and adjusting fill radius
- slightly widen spacing between progress bars and their labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae136a5eac8332941c443ad587f244