### PR TITLE
Eliminate bar edge artifacts and document customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ const CONFIG = {
 
 Edit the values, save the file and refresh the browser to apply changes.
 
+## Customization
+
+Visual tweaks are handled through CSS variables defined at the top of `index.html`. Adjusting these values lets you resize or restyle any part of the widget:
+
+- `font-size` on the `html, body` rule changes the base text size.
+- `--barH` controls bar thickness.
+- `--labelW` sets the width of the text labels.
+- `--gap` is the vertical space between rows; `--row-gap` is the gap between a label and its bar.
+- `--padX` / `--padY` adjust the page padding, while `--maxw` caps the overall width.
+- `--radius`, `--borderW`, `--border`, `--track`, `--fill` and `--label` let you tune colors and shapes.
+
+After editing a variable, save the file and reload the page to see the change. Because the fill overlaps the border by `--borderW`, artifacts will not appear even if you change the bar height or border width.
+
 ## Testing
 
 Run the test suite to verify that the HTML structure has the expected elements:

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       --maxw: 100%; /* fits narrow Notion column */
       --barH: 14px; /* slightly thicker bars */
       --labelW: 72px; /* wider for mixed case labels */
+      --borderW: 1px;
       --border: var(--fg);
     }
     @media (prefers-color-scheme: dark){
@@ -61,13 +62,14 @@
       height: var(--barH); /* equal thickness */
       background: var(--track);
       border-radius: var(--radius);
-      box-shadow: 0 0 0 1px var(--border);
+      border: var(--borderW) solid var(--border);
       box-sizing: border-box;
       overflow: hidden;
     }
     .fill{
       position: absolute;
-      inset: 0 auto 0 0; /* left to right fill */
+      top: 0; bottom: 0;
+      left: calc(var(--borderW) * -1); /* overlap border */
       width: 0%;
       background: var(--fill);
       border-radius: 0 var(--radius) var(--radius) 0;


### PR DESCRIPTION
## Summary
- replace box-shadow border with true border and overlap fill to remove left-edge artefact
- expose `--borderW` CSS variable and expand README with guidance on tweaking size, gaps and colours

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef92744748332991fc0ec66142db7